### PR TITLE
Fix bug

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -219,7 +219,7 @@ jobs:
 
         - name: Build package
           id: build-package
-          run: build-package
+          run: make build-package
 
         - name: Upload assets
           id: upload-assets
@@ -270,7 +270,7 @@ jobs:
         id: publish-package
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: publish-package
+        run: make publish-package
 
       - name: Check
         id: check


### PR DESCRIPTION
This pull request includes changes to the `jobs:` section in the `.github/workflows/cd.yml` file to standardize the build and publish commands using `make`.

Standardization of commands:

* `jobs:` section in `.github/workflows/cd.yml`: Updated the `run` command for building the package to use `make build-package` instead of `build-package`.
* `jobs:` section in `.github/workflows/cd.yml`: Updated the `run` command for publishing the package to use `make publish-package` instead of `publish-package`.