### PR TITLE
Add more Collection types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ uv-install-dev-test:
 	uv sync --link-mode=copy --no-cache --group=dev --group=test
 uv-install-all:
 	uv sync --link-mode=copy --no-cache --all-groups
+uv-lock:
+	uv lock --link-mode=copy
 uv-sync-main: uv-install-main
 uv-sync-dev: uv-install-dev
 uv-sync-docs: uv-install-docs
@@ -85,6 +87,7 @@ uv-sync-dev-test: uv-install-dev-test
 uv-sync-all: uv-install-all
 uv-sync: uv-install-all
 uv-update: uv-install-all
+uv-lock-sync: uv-lock uv-sync
 install: uv-install-main
 install-main: uv-install-main
 install-dev: uv-install-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
 [project]
 name = "toolbox-python"
 version = "1.2.0"
@@ -54,6 +50,7 @@ dev = [
     "pycln==2.*",
     "pylint==3.*",
     "pyupgrade==3.*",
+    # "ruff==0.*",
 ]
 docs = [
     "black==25.*",
@@ -134,6 +131,12 @@ split_on_trailing_comma = true
 combine_as_imports = true
 lines_after_imports = 2
 
+# [tool.ruff.lint.isort]
+# force-wrap-aliases = true
+# split-on-trailing-comma = true
+# combine-as-imports = true
+# lines-after-imports = 2
+
 [tool.codespell]
 ignore-words-list = "demog"
 
@@ -176,4 +179,13 @@ files = [
     { file = "src/toolbox_python/__init__.py", pattern = "__version__ = \"{VERSION}\"" },
     { file = "src/tests/test_version.py", pattern = "__version__ = \"{VERSION}\"" },
     { file = "pyproject.toml", pattern = "version = \"{VERSION}\"" },
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = [
+    "src/toolbox_python",
 ]

--- a/src/toolbox_python/collection_types.py
+++ b/src/toolbox_python/collection_types.py
@@ -19,6 +19,7 @@
 
 
 # ## Python StdLib Imports ----
+from datetime import datetime
 from typing import Any, Literal, Union
 
 
@@ -55,23 +56,44 @@ __all__: list[str] = [
 ## --------------------------------------------------------------------------- #
 
 
+### `str` collections ----
 str_list = list[str]
 str_tuple = tuple[str, ...]
 str_set = set[str]
-str_dict = dict[str, str]
 str_list_tuple = Union[str_list, str_tuple]
+
+### `int` collections ----
 int_list = list[int]
 int_tuple = tuple[int, ...]
+int_set = set[int]
+int_list_tuple = Union[int_list, int_tuple]
+
+### `datetime` collections ----
+datetime_list = list[datetime]
+datetime_tuple = tuple[datetime, ...]
+datetime_set = set[datetime]
+datetime_list_tuple = Union[datetime_list, datetime_tuple]
+
+### `Any` collections ----
 any_list = list[Any]
 any_tuple = tuple[Any, ...]
 any_set = set[Any]
 any_list_tuple = Union[any_list, any_tuple]
+
+### Generic collections ----
 collection = Union[any_list, any_tuple, any_set]
 str_collection = Union[str_list, str_tuple, str_set]
 any_collection = Union[any_list, any_tuple, any_set]
+
+### basic collections ----
 scalar = Union[str, int, float, bool]
 iterable = Union[list, tuple, set, dict]
 
+### `dict` collections ----
+str_dict = dict[str, str]
+dict_str_any = dict[str, Any]
+dict_str_str = dict[str, str]
+dict_int_str = dict[int, str]
 
 dict_any = dict[
     Union[str, int],
@@ -90,7 +112,6 @@ dict_any = dict[
     ```
 """
 
-
 dict_str_int = dict[
     Union[str, int],
     Union[str, int],
@@ -107,11 +128,6 @@ dict_str_int = dict[
     ]
     ```
 """
-
-
-dict_str_any = dict[str, Any]
-dict_str_str = dict[str, str]
-dict_int_str = dict[int, str]
 
 
 log_levels = Literal["debug", "info", "warning", "error", "critical"]


### PR DESCRIPTION
This pull request introduces several updates, including enhancements to the `Makefile` for new commands, modifications to `pyproject.toml` to adjust build configurations and dependencies, and the addition of new type aliases for collections in `collection_types.py`. Below is a summary of the most important changes grouped by theme:

### Build and Command Enhancements:
* Added a new `uv-lock` target to the `Makefile` for locking dependencies and a `uv-lock-sync` target to combine locking and syncing operations. (`[[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R80-R81)`, `[[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R90)`)
* Reintroduced the `[build-system]` section in `pyproject.toml` with `hatchling` as the build backend and added a `[tool.hatch.build.targets.wheel]` section to specify packages for building wheels. (`[pyproject.tomlR183-R191](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R183-R191)`)

### Dependency and Configuration Updates:
* Commented out the `ruff` linter dependency in the `dev` group of `pyproject.toml`. (`[pyproject.tomlR53](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R53)`)
* Added commented-out configuration for `ruff` under `[tool.ruff.lint.isort]` for potential future use. (`[pyproject.tomlR134-R139](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R134-R139)`)

### Type Alias Additions:
* Expanded `collection_types.py` with new type aliases for `int`, `datetime`, and generic collections, as well as additional dictionary type aliases (e.g., `dict_str_any`, `dict_int_str`). (`[[1]](diffhunk://#diff-9f5ce4d362cda9c0c3a74933e8c3bbaf119159709c86bb369219f6540c396b78R59-R96)`, `[[2]](diffhunk://#diff-9f5ce4d362cda9c0c3a74933e8c3bbaf119159709c86bb369219f6540c396b78L93)`, `[[3]](diffhunk://#diff-9f5ce4d362cda9c0c3a74933e8c3bbaf119159709c86bb369219f6540c396b78L112-L116)`)